### PR TITLE
Fixing PLAINTEXT signature building

### DIFF
--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -1078,9 +1078,8 @@ QByteArray QOAuth::InterfacePrivate::createPlaintextSignature( const QByteArray 
         return QByteArray();
     }
 
-    // get percent encoded consumer secret and token secret, join and percent encode once more
-    QByteArray digest = consumerSecret.toPercentEncoding() + "&" + tokenSecret.toPercentEncoding();
-    return digest.toPercentEncoding();
+    // get percent encoded consumer secret and token secret, join and return
+    return consumerSecret.toPercentEncoding() + "&" + tokenSecret.toPercentEncoding();
 }
 
 #include "moc_interface.cpp"


### PR DESCRIPTION
In docs, you've written that PLAINTEXT is not deeply tested. Indeed, I got errors during authorization trials on dropbox.com . The problem is that "&" character is percent-encoded two times: first time in createPlaintextSignature() and second time in createSignature(). With this patch, everything works well.

Dzięki za fajną bibliotekę :)
