### PR TITLE
Windows build fixes

### DIFF
--- a/oauth.prf
+++ b/oauth.prf
@@ -35,8 +35,10 @@ isEmpty(LINKAGE) {
     LIBS += -L$$QOAUTH_LIBDIR
     LINKAGE = -lqoauth
     CONFIG(debug, debug|release) {
-        windows:LINKAGE = -lqoauthd
+        windows:LINKAGE = -lqoauthd1
         mac:LINKAGE = -lqoauth_debug
+    } else {
+        windows:LINKAGE = -lqoauth1
     }
 }
 

--- a/src/interface_p.h
+++ b/src/interface_p.h
@@ -40,7 +40,7 @@ namespace QOAuth {
 class Interface;
 
 
-class InterfacePrivate
+class QOAUTH_EXPORT InterfacePrivate
 {
     Q_DECLARE_PUBLIC(Interface)
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -11,18 +11,32 @@ CONFIG += \
     crypto \
     create_prl
 
-!macx: CONFIG += static_and_shared
 
-OBJECTS_DIR = tmp
-MOC_DIR = tmp
 INC_DIR = ../include
 
 INCLUDEPATH += .
+win32 {
+	CONFIG(debug, debug|release) {
+		BUILDDIR = build/debug
+		windows: TARGET = $$join(TARGET,,,d)
+        mac: TARGET = $$join(TARGET,,,_debug)
+	} else {
+		BUILDDIR = build/release
+	}
+}
+
+INCLUDEPATH += ./$${BUILDDIR}
+MOC_DIR += ./$${BUILDDIR}
+OBJECTS_DIR += ./$${BUILDDIR}
+UI_DIR += ./$${BUILDDIR}
+RCC_DIR += ./$${BUILDDIR}
+
 
 PUBLIC_HEADERS += \
     qoauth_global.h \
     qoauth_namespace.h \
     interface.h
+
 PRIVATE_HEADERS += \
     interface_p.h
 
@@ -76,11 +90,4 @@ else:unix {
         docs \
         pkgconfig \
         features
-}
-
-CONFIG(debug_and_release) {
-    build_pass:CONFIG(debug, debug|release) {
-        unix: TARGET = $$join(TARGET,,,_debug)
-        else: TARGET = $$join(TARGET,,,d)
-    }
 }

--- a/tests/ft_interface/ft_interface.pro
+++ b/tests/ft_interface/ft_interface.pro
@@ -19,6 +19,11 @@ else:unix {
   LIBS += -Wl,-rpath,../../lib:lib
 }
 
+CONFIG(debug, debug|release) {
+    windows: TARGET = $$join(TARGET,,,d)
+    mac: TARGET = $$join(TARGET,,,_debug)
+}
+
 INCLUDEPATH += . ../../src
 HEADERS += ft_interface.h
 SOURCES += ft_interface.cpp

--- a/tests/ut_interface/ut_interface.pro
+++ b/tests/ut_interface/ut_interface.pro
@@ -19,6 +19,11 @@ else:unix {
   LIBS += -Wl,-rpath,../../lib:lib
 }
 
+CONFIG(debug, debug|release) {
+    windows: TARGET = $$join(TARGET,,,d)
+    mac: TARGET = $$join(TARGET,,,_debug)
+}
+
 INCLUDEPATH += . ../../src
 HEADERS += ut_interface.h
 SOURCES += ut_interface.cpp


### PR DESCRIPTION
Now it is possible to build debug and release version on Windows
Tests will be debug and release too

Also I added QOAUTH_EXPORT to InterfacePrivate. It is required to build ft_interface with MSVS2010.
