### PR TITLE
Separate soversion between Qt4 and Qt5

### DIFF
--- a/src/qoauth.pc
+++ b/src/qoauth.pc
@@ -5,7 +5,7 @@ includedir=${prefix}/include/QtOAuth
 
 Name: QOAuth
 Description: Qt OAuth support library
-Version: 1.0.1
+Version: 2.0.1
 Requires: QtCore QtNetwork qca2
 Libs: -L${libdir} -lqoauth
 Cflags: -I${includedir}

--- a/src/src.pro
+++ b/src/src.pro
@@ -2,7 +2,12 @@ TARGET = qoauth
 DESTDIR = ../lib
 win32:DLLDESTDIR = $${DESTDIR}
 
-VERSION = 1.0.1
+equals(QT_MAJOR_VERSION, 5){
+   VERSION = 2.0.1
+}
+equals(QT_MAJOR_VERSION, 4) {
+   VERSION = 1.0.1
+}
 
 TEMPLATE = lib
 QT += network


### PR DESCRIPTION
the pc file got changed too, because it's not edited in the build directory. I think it's fine, but we might want to end up with 2 of them, or enforce qoauth to be used only with Qt5.